### PR TITLE
Correct URL case in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Amatsagu/Tempest
+module github.com/amatsagu/tempest
 
 go 1.22.0


### PR DESCRIPTION
Performing `go get` (as specified in the readme) on this package fails because the module name in `go.mod` doesn't match the GitHub URL casing:
```
$ go get -u github.com/amatsagu/tempest
go: github.com/amatsagu/tempest@upgrade (v1.2.0) requires github.com/amatsagu/tempest@v1.2.0: parsing go.mod:
	module declares its path as: github.com/Amatsagu/Tempest
	        but was required as: github.com/amatsagu/tempest
```

`go get github.com/Amatsagu/Tempest` works, but it is probably best if the module name matches the actual URL and the readme.

If this is merged the imports in `example/` will need to be updated to match.