### PR TITLE
Add min and max_length to Component struct

### DIFF
--- a/component.go
+++ b/component.go
@@ -62,6 +62,8 @@ type Component struct {
 	Options      []*SelectMenuOption `json:"options,omitempty"`
 	Value        string              `json:"value,omitempty"`         // Contains menu choice or text input value from user modal submit.
 	ChannelTypes []*ChannelType      `json:"channel_types,omitempty"` // Only available for 8th ComponentType.
+	MinLength    uint64              `json:"min_length,omitempty"`    // Only available for text input components
+	MaxLength    uint64              `json:"max_length,omitempty"`    // Only available for text input components
 }
 
 // https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-option-structure


### PR DESCRIPTION
### Description

Adds the fields `min_length` and `max_length` to the Component structure, I noticed they were missing.

These fields are used on the Text Input Component, see docs: https://discord.com/developers/docs/interactions/message-components#text-input-object