### PR TITLE
Provide client for modal/command interactions

### DIFF
--- a/client-handler.go
+++ b/client-handler.go
@@ -144,6 +144,7 @@ func (client *Client) HandleDiscordRequest(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		itx.Client = client
 		fn, available := client.modals[itx.Data.CustomID]
 		if available && fn != nil {
 			itx.w = w

--- a/client-handler.go
+++ b/client-handler.go
@@ -55,6 +55,8 @@ func (client *Client) HandleDiscordRequest(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		itx.Client = client
+
 		w.WriteHeader(http.StatusNoContent)
 
 		if !command.AvailableInDM && interaction.GuildID == 0 {


### PR DESCRIPTION
Closes #33 by setting the `Client` field within the `CommandInteraction` and `ModalInteraction` structs, so that you can access it as `itx.Client` within command/modal callback functions.

```go
func main() {
  // ...
  client.RegisterModal("some-modal-id", modalHandler)
}

func modalHandler(itx ModalInteraction) {
  // Before
  itx.Client == nil
  
  // After
  itx.Client.SendMessage(itx.ChannelId, Message{ ... }, nil)
}
```