### PR TITLE
fix: make registersubcommands work

### DIFF
--- a/command-handler.go
+++ b/command-handler.go
@@ -28,7 +28,7 @@ func (client *Client) RegisterCommand(cmd Command) error {
 }
 
 func (client *Client) RegisterSubCommand(subCommand Command, parentCommandName string) error {
-	if client.commands.Has(parentCommandName) {
+	if !client.commands.Has(parentCommandName) {
 		return errors.New("missing \"" + parentCommandName + "\" slash command in registry (parent command needs to be registered in client before adding subcommands)")
 	}
 


### PR DESCRIPTION
The first if statement errors if it finds the commands to add the subcommand to... It should be the opposite way. Oops!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the logic for registering subcommands to ensure they can only be added under existing parent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->