### PR TITLE
fix: set type of Flags in message struct to MessageFlags

### DIFF
--- a/message.go
+++ b/message.go
@@ -229,7 +229,7 @@ type Message struct {
 	Type              BitSet              `json:"type,omitempty"` // https://discord.com/developers/docs/resources/channel#message-object-message-types
 	ApplicationID     Snowflake           `json:"application_id,omitempty"`
 	MessageReference  *MessageReference   `json:"message_reference,omitempty"`
-	Flags             uint64              `json:"flags,omitempty"`
+	Flags             MessageFlags        `json:"flags,omitempty"`
 	ReferencedMessage *Message            `json:"referenced_message,omitempty"`
 	Interaction       *MessageInteraction `json:"interaction,omitempty"`
 	Components        []LayoutComponent   `json:"components,omitzero"`


### PR DESCRIPTION
I don't know exactly what caused this, but updating to the newest version of tempest caused the go compiler to complain with fields that were working in 1.3.1. Perhaps this is due to the change from go 1.25.5 to 1.25.6? I don't know. But this is necessary to get it to compile.