### PR TITLE
refactor: change `FindInteractiveComponent` to use a type switch

### DIFF
--- a/component-helper.go
+++ b/component-helper.go
@@ -19,7 +19,7 @@ func FindInteractiveComponent[CC AnyComponent, T InteractiveComponent](component
 				}
 			}
 		case SectionComponent:
-			// Only button is InteractiveComponent for Accessory type.
+			// Only valid interactive component inside section accessories are buttons
 			if c.Accessory._kind() == THUMBNAIL_COMPONENT_TYPE {
 				continue
 			}

--- a/event.go
+++ b/event.go
@@ -153,12 +153,12 @@ type UpdatePresenceEventData struct {
 type CreateGuildEventData struct {
 	*Guild
 
-	JoinedAt    *time.Time   `json:"joined_at"`
-	Large       bool        `json:"large"`
-	Unavailable bool        `json:"unavailable,omitempty"`
-	MemberCount uint32      `json:"member_count"`
+	JoinedAt    *time.Time `json:"joined_at"`
+	Large       bool       `json:"large"`
+	Unavailable bool       `json:"unavailable,omitempty"`
+	MemberCount uint32     `json:"member_count"`
 
 	Members  []Member         `json:"members"`
 	Channels []PartialChannel `json:"channels"`
-	Threads  []PartialChannel  `json:"threads"`
+	Threads  []PartialChannel `json:"threads"`
 }

--- a/interaction.go
+++ b/interaction.go
@@ -138,7 +138,7 @@ type ComponentInteractionData struct {
 //
 // https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
 type ModalInteractionData struct {
-	CustomID   string            `json:"custom_id"`
+	CustomID   string           `json:"custom_id"`
 	Components []ModalComponent `json:"components,omitzero"` // The components that were sent inside the modal, having been filled with user input.
 }
 

--- a/snowflake.go
+++ b/snowflake.go
@@ -40,7 +40,7 @@ func (s *Snowflake) UnmarshalJSON(b []byte) error {
 
 	// Trim quotes without allocation
 	if b[0] == '"' && b[len(b)-1] == '"' {
-		b = b[1:len(b)-1]
+		b = b[1 : len(b)-1]
 	}
 
 	i, err := strconv.ParseUint(string(b), 10, 64)


### PR DESCRIPTION
This significantly improves performance by a LOT for small ones, while only being barely slower (if at all) for larger (valid) nested traversals. (I made the changes for readability for the most part; the perf boost is a nice, unexpected surprise)

<img width="1025" height="112" alt="image" src="https://github.com/user-attachments/assets/38b9a13e-9550-477d-942b-e77bd135206b" />
<img width="1015" height="113" alt="image" src="https://github.com/user-attachments/assets/1ea7e234-f795-4e6f-bb4c-aa593af91c5c" />