### PR TITLE
docs: Improve documentation of various components, structs and examples

### DIFF
--- a/component.go
+++ b/component.go
@@ -12,9 +12,9 @@ const (
 	PREMIUM_BUTTON_STYLE                          // By default same as primary but will automatically use SKU icon, name & price (sky_id field is required)
 )
 
+// https://docs.discord.com/developers/components/reference#component-object
 type ComponentType uint8
 
-// https://docs.discord.com/developers/components/reference#component-object
 const (
 	ACTION_ROW_COMPONENT_TYPE         ComponentType = iota + 1 // Layout component for Messages
 	BUTTON_COMPONENT_TYPE                                      // Interactive component for Messages
@@ -45,7 +45,7 @@ const (
 type TextInputStyle uint8
 
 const (
-	SHORT_TEXT_INPUT_STYLE     TextInputStyle = iota + 1 // 	A single-line input.
+	SHORT_TEXT_INPUT_STYLE     TextInputStyle = iota + 1 // A single-line input.
 	PARAGRAPH_TEXT_INPUT_STYLE                           // A multi-line input.
 )
 
@@ -81,15 +81,18 @@ type ActionRowComponent struct {
 //
 // https://docs.discord.com/developers/components/reference#button
 type ButtonComponent struct {
-	Type     ComponentType `json:"type"` // Always = BUTTON_COMPONENT_TYPE (2)
-	ID       uint32        `json:"id,omitempty"`
-	Style    ButtonStyle   `json:"style"`
-	Label    string        `json:"label,omitempty"`
-	Emoji    *Emoji        `json:"emoji,omitempty"` // It may only contain id, name, and animated from regular Emoji struct.
-	CustomID string        `json:"custom_id,omitempty"`
-	SkuID    Snowflake     `json:"sku_id,omitempty"` // Identifier for a purchasable SKU, only available when using premium-style buttons. Premium buttons do not send an interaction to your app when clicked.
-	URL      string        `json:"url,omitempty"`
-	Disabled bool          `json:"disabled"`
+	Type  ComponentType `json:"type"` // Always = BUTTON_COMPONENT_TYPE (2)
+	ID    uint32        `json:"id,omitempty"`
+	Style ButtonStyle   `json:"style"`
+	Label string        `json:"label,omitempty"`
+	Emoji *Emoji        `json:"emoji,omitempty"` // It may only contain id, name, and animated from regular Emoji struct.
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
+	CustomID string    `json:"custom_id,omitempty"`
+	SkuID    Snowflake `json:"sku_id,omitempty"` // Identifier for a purchasable SKU, only available when using premium-style buttons. Premium buttons do not send an interaction to your app when clicked.
+	URL      string    `json:"url,omitempty"`
+	Disabled bool      `json:"disabled"`
 }
 
 // A StringSelectComponent displays a dropdown menu for users to select one or more pre-defined options.
@@ -99,20 +102,26 @@ type ButtonComponent struct {
 //
 // https://docs.discord.com/developers/components/reference#string-select
 type StringSelectComponent struct {
-	Type        ComponentType      `json:"type"` // Always = STRING_SELECT_COMPONENT_TYPE (3). For responses, only provided for modal interactions
-	ID          uint32             `json:"id,omitempty"`
+	Type ComponentType `json:"type"` // Always = STRING_SELECT_COMPONENT_TYPE (3). Omitted inside interaction responses from messages.
+	ID   uint32        `json:"id,omitempty"`
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID    string             `json:"custom_id,omitempty"`
 	Options     []SelectMenuOption `json:"options,omitzero"`
 	Placeholder string             `json:"placeholder,omitempty"`
-	MinValues   uint8              `json:"min_values,omitempty"`
-	MaxValues   uint8              `json:"max_values,omitempty"`
-	Disabled    bool               `json:"disabled"`
-	Required    bool               `json:"required"`
+	MinValues   uint8              `json:"min_values,omitempty"` // The minimum number of options that must be chosen; defaults to 0 and must be between 0 and 25. Can only be 0 if required is set to false.
+	MaxValues   uint8              `json:"max_values,omitempty"` // The maximum number of options that can be chosen; defaults to 1 and must be between 1 and 25.
+	Disabled    bool               `json:"disabled"`             // Whether the select menu is disabled inside a message; default false. Will result in an error if used inside a modal!
+	Required    bool               `json:"required"`             // Whether a selection is required to submit the modal; defaults to true. Will result in an error if used inside a message!
 
-	// Below 2 fields are controlled by API and should be readonly for us, developers.
-	// https://docs.discord.com/developers/components/reference#string-select-string-select-interaction-response-structure
-	ComponentType ComponentType `json:"component_type,omitempty"` // This field is ignored and provided by the API as part of the response (only provided for message interaction)
-	Values        []string      `json:"values,omitzero"`          // This field is ignored and provided by the API as part of the response.
+	// The following 2 fields are sent by Discord's API upon a successful interaction response.
+	// They should not be sent by developers when sending a message or modal, being either ignored or causing runtime payload rejection.
+	// Source: https://docs.discord.com/developers/components/reference#string-select-string-select-interaction-response-structure
+	// TODO: Have someone try throwing an invalid payload with these fields at discord to see how they respond (and update the above comment accordingly)
+
+	ComponentType ComponentType `json:"component_type,omitempty"` // Always = STRING_SELECT_COMPONENT_TYPE (3). Omitted in anything BUT interaction responses from messages.
+	Values        []string      `json:"values,omitzero"`          // The values of the options that were selected by the user. Should not be provided during message or modal creation.
 }
 
 // A SelectMenuOption represents a single option within a [StringSelectComponent].
@@ -128,12 +137,15 @@ type SelectMenuOption struct {
 
 // A TextInputComponent displays a field for the user to input free-form text.
 //
-// They can only be used inside [LabelComponents] within modals.
+// They can only be used inside [LabelComponent]s within modals.
 //
 // https://docs.discord.com/developers/components/reference#text-input
 type TextInputComponent struct {
-	Type        ComponentType  `json:"type"` // Always = TEXT_INPUT_COMPONENT_TYPE (4)
-	ID          uint32         `json:"id,omitempty"`
+	Type ComponentType `json:"type"` // Always = TEXT_INPUT_COMPONENT_TYPE (4)
+	ID   uint32        `json:"id,omitempty"`
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID    string         `json:"custom_id,omitempty"`
 	Style       TextInputStyle `json:"style"`
 	Label       string         `json:"label,omitempty"`       // Deprecated: use `label` and `description` on a Label component instead
@@ -155,14 +167,17 @@ type TextInputComponent struct {
 // [Mentionable Select]: https://docs.discord.com/developers/components/reference#mentionable-select-mentionable-select-structure
 // [Channel Select]: https://docs.discord.com/developers/components/reference#channel-select-channel-select-structure
 type SelectComponent struct {
-	Type          ComponentType        `json:"type"` // Either USER_SELECT_COMPONENT_TYPE, ROLE_SELECT_COMPONENT_TYPE, MENTIONABLE_SELECT_COMPONENT_TYPE or CHANNEL_SELECT_COMPONENT_TYPE
-	ID            uint32               `json:"id,omitempty"`
+	Type ComponentType `json:"type"` // Either USER_SELECT_COMPONENT_TYPE, ROLE_SELECT_COMPONENT_TYPE, MENTIONABLE_SELECT_COMPONENT_TYPE or CHANNEL_SELECT_COMPONENT_TYPE
+	ID   uint32        `json:"id,omitempty"`
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID      string               `json:"custom_id,omitempty"`
-	ChannelTypes  []ChannelType        `json:"channel_types,omitzero"`  // List of channel types to include in the channel select component; should be omitted for all other select types
-	Placeholder   string               `json:"placeholder,omitempty"`   // Placeholder text if nothing is selected, max: 150 characters
-	DefaultValues []DefaultValueOption `json:"default_values,omitzero"` // List of default values for auto-populated select menu components; must have between MinValues and MaxValues entries
-	MinValues     uint8                `json:"min_values,omitempty"`    // The minimum number of items that must be chosen; defaults to 1 and must be between 0 and 25
-	MaxValues     uint8                `json:"max_values,omitempty"`    // The maximum number of items that can be chosen; defaults to 1 and must be between 0 and 25
+	ChannelTypes  []ChannelType        `json:"channel_types,omitzero"`  // List of channel types to include in the channel select component; should be omitted for all other select types.
+	Placeholder   string               `json:"placeholder,omitempty"`   // Placeholder text if nothing is selected, max: 150 characters.
+	DefaultValues []DefaultValueOption `json:"default_values,omitzero"` // List of default values for auto-populated select menu components; must have between MinValues and MaxValues entries.
+	MinValues     uint8                `json:"min_values,omitempty"`    // The minimum number of items that must be chosen; defaults to 1 and must be between 0 and 25.
+	MaxValues     uint8                `json:"max_values,omitempty"`    // The maximum number of items that can be chosen; defaults to 1 and must be between 0 and 25.
 	Disabled      bool                 `json:"disabled"`                // Whether the select menu is disabled inside a message; default false. Will result in an error if used inside a modal!
 }
 
@@ -279,30 +294,35 @@ type LabelComponent struct {
 	Component   LabelChildComponent `json:"component"`             // The component nested within the label.
 }
 
-// File Upload is an interactive component that allows users to upload files in modals.
-// File Uploads can be configured to have a minimum and maximum number of files between 0 and 10,
-// along with required for if the upload is required to submit the modal.
-// The max file size a user can upload is based on the user’s upload limit in that channel.
+// A FileUploadComponent allows users to upload one or more files in modals.
+// The maximum file size a user can upload is based solely on the user’s upload limit in that channel.
 //
-// File Uploads are available on modals. They must be placed inside a Label Component(s).
+// They can only be used inside [LabelComponent]s within modals.
 //
 // https://docs.discord.com/developers/components/reference#file-upload
 type FileUploadComponent struct {
-	Type      ComponentType `json:"type"`         // Always = FILE_UPLOAD_COMPONENT_TYPE (19)
-	ID        uint32        `json:"id,omitempty"` // Optional identifier for component
-	CustomID  string        `json:"custom_id,omitempty"`
-	MinValues uint8         `json:"min_values,omitempty"`
-	MaxValues uint8         `json:"max_values,omitempty"`
-	Required  bool          `json:"required"`
+	Type ComponentType `json:"type"`         // Always = FILE_UPLOAD_COMPONENT_TYPE (19)
+	ID   uint32        `json:"id,omitempty"` // Optional identifier for component
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
+	CustomID  string `json:"custom_id,omitempty"`
+	MinValues uint8  `json:"min_values,omitempty"` // The minimum number of files that must be uploaded; defaults to 1 and must be between 0 and 10. Can only be 0 if required is set to false.
+	MaxValues uint8  `json:"max_values,omitempty"` // The maximum number of files that can be uploaded; defaults to 1 and must be between 1 and 10.
+	Required  bool   `json:"required"`             // Whether a file upload is required to submit the modal.
 }
 
-// A Radio Group is an interactive component for selecting exactly one option from a defined list.
-// Radio Groups are available in modals and must be placed inside a Label Component(s).
+// A RadioGroupComponent allows selecting exactly one option from a defined list of choices.
+//
+// They can only be used inside [LabelComponent]s within modals.
 //
 // https://docs.discord.com/developers/components/reference#radio-group
 type RadioGroupComponent struct {
-	Type     ComponentType      `json:"type"`         // Always = RADIO_GROUP_COMPONENT_TYPE (21)
-	ID       uint32             `json:"id,omitempty"` // Optional identifier for component
+	Type ComponentType `json:"type"`         // Always = RADIO_GROUP_COMPONENT_TYPE (21)
+	ID   uint32        `json:"id,omitempty"` // Optional identifier for component
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID string             `json:"custom_id,omitempty"`
 	Options  []RadioGroupOption `json:"options,omitzero"` // List of options to show; min 2, max 10
 	Required bool               `json:"required"`         // Whether a selection is required to submit the modal (defaults to true)
@@ -316,18 +336,22 @@ type RadioGroupOption struct {
 	Default     bool   `json:"default"` // Whether to render this option as selected by default.
 }
 
-// A Checkbox Group is an interactive component for selecting one or many options via checkboxes.
-// Checkbox Groups are available in modals and must be placed inside a Label Component(s).
+// A CheckboxGroupComponent displays a list of one or more options selectable via checkboxes.
+//
+// They can only be used inside [LabelComponent]s within modals.
 //
 // https://docs.discord.com/developers/components/reference#checkbox-group
 type CheckboxGroupComponent struct {
-	Type      ComponentType         `json:"type"`         // Always = CHECKBOX_GROUP_COMPONENT_TYPE (22)
-	ID        uint32                `json:"id,omitempty"` // Optional identifier for component
+	Type ComponentType `json:"type"`         // Always = CHECKBOX_GROUP_COMPONENT_TYPE (22)
+	ID   uint32        `json:"id,omitempty"` // Optional identifier for component
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID  string                `json:"custom_id,omitempty"`
-	Options   []CheckboxGroupOption `json:"options,omitzero"`
-	MinValues uint8                 `json:"min_values,omitempty"`
-	MaxValues uint8                 `json:"max_values,omitempty"`
-	Required  bool                  `json:"required"`
+	Options   []CheckboxGroupOption `json:"options,omitzero"`     // The options to show in this checkbox group; must be between 1 and 10 options.
+	MinValues uint8                 `json:"min_values,omitempty"` // The minimum number of options that must be chosen; defaults to 1 and must be between 0 and 10. Can only be 0 if required is set to false.
+	MaxValues uint8                 `json:"max_values,omitempty"` // The maximum number of options that can be chosen; must be between 1 and 10.
+	Required  bool                  `json:"required"`             // Whether a selection is required to submit the modal (defaults to true).
 }
 
 // https://docs.discord.com/developers/components/reference#checkbox-group-option-structure
@@ -338,13 +362,17 @@ type CheckboxGroupOption struct {
 	Default     bool   `json:"default"` // Whether to render this option as selected by default.
 }
 
-// A Checkbox is a single interactive component for simple yes/no style questions.
-// Checkboxes are available in modals and must be placed inside a Label Component(s).
+// A CheckboxComponent displays a single, non-required yes/no style question.
+//
+// They can only be used inside [LabelComponent]s within modals.
 //
 // https://docs.discord.com/developers/components/reference#checkbox
 type CheckboxComponent struct {
-	Type     ComponentType `json:"type"`         // Always = CHECKBOX_COMPONENT_TYPE (23)
-	ID       uint32        `json:"id,omitempty"` // Optional identifier for component
-	CustomID string        `json:"custom_id,omitempty"`
-	Default  bool          `json:"default"` // Whether to render this option as selected by default.
+	Type ComponentType `json:"type"`         // Always = CHECKBOX_COMPONENT_TYPE (23)
+	ID   uint32        `json:"id,omitempty"` // Optional identifier for component
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
+	CustomID string `json:"custom_id,omitempty"`
+	Default  bool   `json:"default"` // Whether to render this option as selected by default.
 }

--- a/example/internal/command/modal.go
+++ b/example/internal/command/modal.go
@@ -25,7 +25,6 @@ var Modal tempest.Command = tempest.Command{
 				},
 			},
 		})
-
 		if err != nil {
 			log.Println("failed to send modal", err)
 		}
@@ -34,25 +33,26 @@ var Modal tempest.Command = tempest.Command{
 
 func HelloModal(itx tempest.ModalInteraction) {
 	var value string
-	// if row, ok := itx.Data.Components[0].(tempest.LabelComponent); ok {
-	// 	if textInput, ok := row.Components[0].(tempest.TextInputComponent); ok {
-	//      // This if check is an example, not required in this example as it has only 1 component in total.
-	// 		if textInput.CustomID == "example-test-input" {
-	// 			value = textInput.Value
-	// 		}
-	// 	}
-	// }
-
-	// This is just an example that lib provides helped function to traverse component trees.
-	// In case you work with interaction that you know has just 1-2 interactive components, use manual code for better performance.
-	textInput, ok := tempest.FindInteractiveComponent(
-		itx.Data.Components,
-		func(cmp tempest.TextInputComponent) bool { return cmp.CustomID == "example-test-input" },
-	)
-
-	if ok {
-		value = textInput.Value
+	if row, ok := itx.Data.Components[0].(tempest.LabelComponent); ok {
+		if textInput, ok := row.Component.(tempest.TextInputComponent); ok {
+			// This if check is technically redundant since we already know what the 1st text input field contains, but
+			// illustrates that Discord will send these back verbatim (so you could use it to encode state).
+			if textInput.CustomID == "example-test-input" {
+				value = textInput.Value
+			}
+		}
 	}
+
+	// NB: The below commented code is an alternate means of retrieving the component's value using a builtin helper.
+	// FindInteractiveComponent is mostly useful for larger, more complex component trees where manually checking individual components would be infeasible;
+	// users with simpler component hierarchies should prefer the manual approach for higher performance.
+
+	// if textInput, ok := tempest.FindInteractiveComponent(
+	// 	itx.Data.Components,
+	// 	func(cmp tempest.TextInputComponent) bool { return cmp.CustomID == "example-test-input" },
+	// ); ok {
+	// 	value = textInput.Value
+	// }
 
 	if value == "" {
 		itx.AcknowledgeWithLinearMessage("Oh, how about trying pizza?", false)

--- a/example/internal/command/modal.go
+++ b/example/internal/command/modal.go
@@ -36,7 +36,7 @@ func HelloModal(itx tempest.ModalInteraction) {
 	if row, ok := itx.Data.Components[0].(tempest.LabelComponent); ok {
 		if textInput, ok := row.Component.(tempest.TextInputComponent); ok {
 			// This if check is technically redundant since we already know what the 1st text input field contains, but
-			// illustrates that Discord will send these back verbatim (so you could use it to encode state).
+			// illustrates that Discord will send component Custom IDs back verbatim (so you could use them to encode state).
 			if textInput.CustomID == "example-test-input" {
 				value = textInput.Value
 			}

--- a/interaction.go
+++ b/interaction.go
@@ -137,13 +137,9 @@ type CommandOptionChoice struct {
 	Value             any                 `json:"value"`                       // string, float64 (double or integer) or bool
 }
 
-//
-//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-message-component-data-structure
 type ComponentInteractionData struct {
-	// A unique, developer-defined identifier for this interaction; must be between 1 and 100 characters long.
-	//
-	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
+	// The CustomID of the Component having been interacted with.
 	CustomID string                   `json:"custom_id"`
 	Type     ComponentType            `json:"component_type"`  // The type of the component having been interacted with.
 	Values   []string                 `json:"values,omitzero"` // Values the user selected in a select menu component
@@ -154,7 +150,7 @@ type ComponentInteractionData struct {
 //
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
 type ModalInteractionData struct {
-	// The CustomID of the modal having been submitted. 
+	// The CustomID of the modal having been submitted.
 	CustomID   string           `json:"custom_id"`
 	Components []ModalComponent `json:"components,omitzero"` // The components that were sent inside the modal, having been filled with user input.
 }

--- a/interaction.go
+++ b/interaction.go
@@ -71,42 +71,53 @@ type Interaction struct {
 	responder     func(res Response) error `json:"-"`
 }
 
+// A CommandInteraction represents an interaction received from a user invoking an application command, such as a slash command or a context menu command.
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object
 type CommandInteraction struct {
 	*Interaction
 	Data CommandInteractionData `json:"data"`
 }
 
+// A ComponentInteraction represents an interaction received from a user interacting with a message component,
+// such as a [ButtonComponent] or [SelectComponent].
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object
 type ComponentInteraction struct {
 	*Interaction
 	Data ComponentInteractionData `json:"data"`
 }
 
+// A ModalInteraction represents an interaction received from a user submitting a modal.
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object
 type ModalInteraction struct {
 	*Interaction
 	Data ModalInteractionData `json:"data"`
 }
 
+// A CommandInteractionData represents the data received from a user invoking an application command, such as a slash command or a context menu command.
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-interaction-data
 type CommandInteractionData struct {
-	ID       Snowflake                  `json:"id"`
-	Name     string                     `json:"name"`
-	Type     CommandType                `json:"type"`
-	Resolved *InteractionDataResolved   `json:"resolved,omitempty"`
-	Options  []CommandInteractionOption `json:"options,omitzero"`
-	GuildID  Snowflake                  `json:"guild_id,omitempty"`
-	TargetID Snowflake                  `json:"target_id,omitempty"` // ID of either user or message targeted. Depends whether it was user command or message command.
+	ID       Snowflake                  `json:"id"`                  // The ID of the invoked command.
+	Name     string                     `json:"name"`                // The name of the invoked command, not including subcommand names.
+	Type     CommandType                `json:"type"`                // The type of comamnd that was invoked.
+	Resolved *InteractionDataResolved   `json:"resolved,omitempty"`  // Data that Discord has resolved for the command, such as user and role objects. Fields will only be available to bots with the requisite permissions.
+	Options  []CommandInteractionOption `json:"options,omitzero"`    // The options and values passed by the user.
+	GuildID  Snowflake                  `json:"guild_id,omitempty"`  // The ID of the guild the command was invoked from. Will be null (i.e. 0) if invoked in a DM.
+	TargetID Snowflake                  `json:"target_id,omitempty"` // The ID of the user or message targeted by a user or message command from the context menu. Will be empty for slash commands.
 }
 
+// A CommandInteractionOption represents data about a single option passed to a command.
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-application-command-interaction-data-option-structure
 type CommandInteractionOption struct {
-	Name    string                     `json:"name"`
-	Type    OptionType                 `json:"type"`
-	Value   any                        `json:"value,omitempty"` // string, float64 (double or integer) or bool
-	Options []CommandInteractionOption `json:"options,omitzero"`
-	Focused bool                       `json:"focused"`
+	Name    string                     `json:"name"`             // The name of the option.
+	Type    OptionType                 `json:"type"`             // The type of option that was provided.
+	Value   any                        `json:"value,omitempty"`  // The value provided by the user; will always be of type string, float64 (double/integer) or bool. Mutually exclusive with options.
+	Options []CommandInteractionOption `json:"options,omitzero"` // For subcommands or grouped commands, the options passed to the subcommand or group. Mutually exclusive with value.
+	Focused bool                       `json:"focused"`          // Whether this option is currently focused by the user during autocomplete. Is exclusively used for autocomplete interactions and will always be false otherwise.
 }
 
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-resolved-data-structure
@@ -126,10 +137,15 @@ type CommandOptionChoice struct {
 	Value             any                 `json:"value"`                       // string, float64 (double or integer) or bool
 }
 
+//
+//
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-message-component-data-structure
 type ComponentInteractionData struct {
+	// A unique, developer-defined identifier for this interaction; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
 	CustomID string                   `json:"custom_id"`
-	Type     ComponentType            `json:"component_type"`
+	Type     ComponentType            `json:"component_type"`  // The type of the component having been interacted with.
 	Values   []string                 `json:"values,omitzero"` // Values the user selected in a select menu component
 	Resolved *InteractionDataResolved `json:"resolved,omitempty"`
 }
@@ -138,6 +154,7 @@ type ComponentInteractionData struct {
 //
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object-modal-submit-data-structure
 type ModalInteractionData struct {
+	// The CustomID of the modal having been submitted. 
 	CustomID   string           `json:"custom_id"`
 	Components []ModalComponent `json:"components,omitzero"` // The components that were sent inside the modal, having been filled with user input.
 }

--- a/response.go
+++ b/response.go
@@ -59,7 +59,10 @@ type ResponseAutoCompleteData struct {
 //
 // https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-response-object-modal
 type ResponseModalData struct {
-	CustomID   string           `json:"custom_id"`           // A custom identifier for the modal. Must be non-empty and between 1-100 characters.
+	// A unique, developer-defined identifier for this Component; must be between 1 and 100 characters long.
+	//
+	// Will be returned verbatim inside the response payload, and be used to maintain application state or store data as needed.
+	CustomID   string           `json:"custom_id"`
 	Title      string           `json:"title"`               // The title of the modal. Must be under 45 characters.
 	Components []ModalComponent `json:"components,omitzero"` // 1-5 components that will make up the modal's body. Will be returned populated with user-filled data.
 }


### PR DESCRIPTION
As per usual, I spotted some areas for improvement in the docs when working on various affairs. \
Me being an insatiable lunatic that cannot stand imperfection or inconsistency, I took it upon myself to fix things. :)

pls squash merge for my sake and yours

> [!NOTE]
> The diff is artificially inflated due to the added multiline comments for `CustomId` affecting `gofmt` struct field alignment. 